### PR TITLE
feat(cipher): expose ratchet counter and key from decrypt methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,19 @@
   `stopWorker`, `util`, the `curvePubKeyToEd25519PubKey` /
   `ed25519PubKeyToCurvePubKey` conversion helpers, and the public types/enums.
 
+### Breaking: decrypt methods now return a `DecryptResult`
+
+- `SessionCipher.decryptWhisperMessage` and `decryptPreKeyWhisperMessage` now
+  resolve to a `DecryptResult` (`{ plaintext, ratchet: { counter, key } }`)
+  instead of a bare plaintext `ArrayBuffer`. Existing callers must destructure
+  `plaintext` from the result.
+- `ratchet.counter` is the message index within the sender's current chain and
+  `ratchet.key` is the sender's ratchet (DH) public key in the internal 33-byte
+  `0x05`-prefixed curve form. Both are normalized identically across the legacy
+  (0.3.0) and `omemo:2` profiles, and let consumers implement protocol rules
+  such as the OMEMO heartbeat (XEP-0384).
+- New exported `DecryptResult` type.
+
 ## 1.0.0
 
 ### Breaking: `OMEMOStore` identity methods now receive full address string

--- a/README.md
+++ b/README.md
@@ -162,18 +162,23 @@ const ciphertext = await sessionCipher.encrypt("Hello world");
 
 ### Decrypting Messages
 
+Both decrypt methods resolve to a `DecryptResult`:
+
 ```js
 const sessionCipher = new SessionCipher(store, address, "urn:xmpp:omemo:2");
 
 // Decrypt a PreKey/key-exchange message (establishes session if needed)
 try {
-    const plaintext = await sessionCipher.decryptPreKeyWhisperMessage(ciphertext);
+    const { plaintext } = await sessionCipher.decryptPreKeyWhisperMessage(ciphertext);
 } catch (error) {
     // Handle identity key conflict
 }
 
 // Decrypt a regular message using existing session
-const plaintext = await sessionCipher.decryptWhisperMessage(ciphertext);
+const { plaintext, ratchet } = await sessionCipher.decryptWhisperMessage(ciphertext);
+// `ratchet.counter` (message index in the sender's chain) and `ratchet.key`
+// (the sender's 33-byte 0x05-prefixed ratchet public key) let you implement
+// protocol rules such as the OMEMO heartbeat.
 ```
 
 ### Selecting the OMEMO version

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "libomemo.js",
-    "version": "2.0.0-rc.1",
+    "version": "2.0.0-rc.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "libomemo.js",
-            "version": "2.0.0-rc.1",
+            "version": "2.0.0-rc.2",
             "license": "GPL-3.0",
             "dependencies": {
                 "protobufjs": "^8.0.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "libomemo.js",
     "repository": "github:conversejs/libomemo.js",
-    "version": "2.0.0-rc.1",
+    "version": "2.0.0-rc.2",
     "license": "GPL-3.0",
     "type": "module",
     "main": "./dist/libomemo.umd.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,5 +24,6 @@ export type {
     OMEMOVersion,
     KeyId,
     EncryptResult,
+    DecryptResult,
     IdentityKeyError,
 } from "./session/types";

--- a/src/session/cipher.ts
+++ b/src/session/cipher.ts
@@ -8,6 +8,7 @@ import { ChainType } from "../types";
 import { getProtocolProfile, ProtocolProfile, MacContext, toExactBuffer } from "./protocol-profile";
 import {
     EncryptResult,
+    DecryptResult,
     SessionState,
     OMEMOStore,
     OMEMOVersion,
@@ -165,7 +166,7 @@ export class SessionCipher {
     async #doDecryptWhisperMessage(
         messageBytes: ArrayBuffer,
         session: SessionState | undefined
-    ): Promise<ArrayBuffer> {
+    ): Promise<DecryptResult> {
         if (!(messageBytes instanceof ArrayBuffer)) {
             throw new Error("Expected messageBytes to be an ArrayBuffer");
         }
@@ -216,14 +217,17 @@ export class SessionCipher {
 
         const plaintext = await decrypt(keys[0], parsed.ciphertext, keys[2].slice(0, 16));
         delete session.pendingPreKey;
-        return plaintext;
+        return {
+            plaintext,
+            ratchet: { counter: parsed.counter, key: parsed.ephemeralKey },
+        };
     }
 
     async #decryptWithSessionList(
         buffer: ArrayBuffer,
         sessionList: SessionState[],
         errors: unknown[] = []
-    ): Promise<{ plaintext: ArrayBuffer; session: SessionState }> {
+    ): Promise<{ result: DecryptResult; session: SessionState }> {
         if (sessionList.length === 0) {
             return Promise.reject(errors[0]);
         }
@@ -231,7 +235,7 @@ export class SessionCipher {
         const session = sessionList.pop()!;
         try {
             return {
-                plaintext: await this.#doDecryptWhisperMessage(buffer, session),
+                result: await this.#doDecryptWhisperMessage(buffer, session),
                 session,
             };
         } catch (e: unknown) {
@@ -346,7 +350,7 @@ export class SessionCipher {
     async decryptWhisperMessage(
         buffer: string | ArrayBuffer | Uint8Array,
         encoding: string
-    ): Promise<ArrayBuffer> {
+    ): Promise<DecryptResult> {
         const normalized = util.normalizeBuffer(buffer, encoding);
         const exact = toExactBuffer(normalized);
         return queueJobForNumber(this.#remoteAddress.toString(), async () => {
@@ -355,7 +359,7 @@ export class SessionCipher {
             const record = await this.#getRecord(address);
             if (!record) throw new Error(`No record for device ${address}`);
 
-            const { session, plaintext } = await this.#decryptWithSessionList(
+            const { session, result } = await this.#decryptWithSessionList(
                 exact,
                 record.getSessions()
             );
@@ -378,7 +382,7 @@ export class SessionCipher {
 
             await this.#store.storeSession(address, record.serialize());
 
-            return plaintext;
+            return result;
         });
     }
 
@@ -386,7 +390,7 @@ export class SessionCipher {
     decryptPreKeyWhisperMessage(
         buffer: string | ArrayBuffer | Uint8Array,
         encoding: string
-    ): Promise<ArrayBuffer> {
+    ): Promise<DecryptResult> {
         const normalized = util.normalizeBuffer(buffer, encoding);
         const exact = toExactBuffer(normalized);
 
@@ -410,14 +414,14 @@ export class SessionCipher {
             const preKeyId = await builder.processV3(record, parsed);
 
             const session = record.getSessionByBaseKey(parsed.baseKey);
-            const plaintext = await this.#doDecryptWhisperMessage(parsed.message, session);
+            const result = await this.#doDecryptWhisperMessage(parsed.message, session);
             record.updateSessionState(session!);
             await this.#store.storeSession(address, record.serialize());
 
             if (preKeyId !== undefined && preKeyId !== null) {
                 await this.#store.removePreKey(preKeyId);
             }
-            return plaintext;
+            return result;
         });
     }
 

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -41,6 +41,28 @@ export interface EncryptResult {
     kex?: boolean;
 }
 
+/**
+ * The result of decrypting a (pre-key or regular) ratchet message.
+ *
+ * `ratchet` exposes the Double Ratchet state of the decrypted message, which
+ * consumers need to implement protocol rules such as the OMEMO heartbeat
+ * (XEP-0384: "the first message for a given ratchet key with a counter of 53
+ * or higher" must trigger a heartbeat).
+ */
+export interface DecryptResult {
+    /** The decrypted plaintext. */
+    plaintext: ArrayBuffer;
+    ratchet: {
+        /** The message counter (index within the sender's current chain). */
+        counter: number;
+        /**
+         * The sender's ratchet (DH) public key for this message, in the
+         * internal 33-byte `0x05`-prefixed curve form.
+         */
+        key: ArrayBuffer;
+    };
+}
+
 export interface RatchetState {
     rootKey: ArrayBuffer;
     lastRemoteEphemeralKey: ArrayBuffer;

--- a/test/omemo2.ts
+++ b/test/omemo2.ts
@@ -103,7 +103,7 @@ describe("OMEMO end-to-end (both versions)", function () {
                 if (version === "urn:xmpp:omemo:2") {
                     assert.isTrue(ct.kex);
                 }
-                const pt = await bobCipher.decryptPreKeyWhisperMessage(ct.body, "binary");
+                const { plaintext: pt } = await bobCipher.decryptPreKeyWhisperMessage(ct.body, "binary");
                 assertEqualArrayBuffers(pt, msg);
             });
 
@@ -111,13 +111,13 @@ describe("OMEMO end-to-end (both versions)", function () {
                 const reply = util.toArrayBuffer("reply tuple") as ArrayBuffer;
                 const ct2 = await bobCipher.encrypt(reply);
                 assert.strictEqual(ct2.type, 1);
-                const pt2 = await aliceCipher.decryptWhisperMessage(ct2.body, "binary");
+                const { plaintext: pt2 } = await aliceCipher.decryptWhisperMessage(ct2.body, "binary");
                 assertEqualArrayBuffers(pt2, reply);
 
                 const third = util.toArrayBuffer("third tuple") as ArrayBuffer;
                 const ct3 = await aliceCipher.encrypt(third);
                 assert.strictEqual(ct3.type, 1);
-                const pt3 = await bobCipher.decryptWhisperMessage(ct3.body, "binary");
+                const { plaintext: pt3 } = await bobCipher.decryptWhisperMessage(ct3.body, "binary");
                 assertEqualArrayBuffers(pt3, third);
             });
 
@@ -127,10 +127,46 @@ describe("OMEMO end-to-end (both versions)", function () {
                 const c1 = await aliceCipher.encrypt(m1);
                 const c2 = await aliceCipher.encrypt(m2);
                 // Deliver the second message first.
-                const p2 = await bobCipher.decryptWhisperMessage(c2.body, "binary");
-                const p1 = await bobCipher.decryptWhisperMessage(c1.body, "binary");
+                const { plaintext: p2 } = await bobCipher.decryptWhisperMessage(c2.body, "binary");
+                const { plaintext: p1 } = await bobCipher.decryptWhisperMessage(c1.body, "binary");
                 assertEqualArrayBuffers(p2, m2);
                 assertEqualArrayBuffers(p1, m1);
+            });
+
+            it("exposes the ratchet counter and key on decryption", async function () {
+                // Use a fresh session so the counters are deterministic.
+                const aStore = new InMemoryStore();
+                const bStore = new InMemoryStore();
+                await Promise.all([generateIdentity(aStore), generateIdentity(bStore)]);
+                const bundle = await makeBundle(bStore, version, 4242, 2);
+                await new SessionBuilder(aStore, BOB, version).processPreKey(bundle);
+                const aCipher = new SessionCipher(aStore, BOB, version);
+                const bCipher = new SessionCipher(bStore, ALICE, version);
+
+                // Alice's first message is a key-exchange; its inner counter is 0.
+                const m0 = util.toArrayBuffer("kex") as ArrayBuffer;
+                const c0 = await aCipher.encrypt(m0);
+                const r0 = await bCipher.decryptPreKeyWhisperMessage(c0.body, "binary");
+                assertEqualArrayBuffers(r0.plaintext, m0);
+                assert.strictEqual(r0.ratchet.counter, 0);
+                // The ratchet key is the internal 33-byte 0x05-prefixed curve form.
+                assert.strictEqual(r0.ratchet.key.byteLength, 33);
+                assert.strictEqual(new Uint8Array(r0.ratchet.key)[0], 5);
+
+                // Bob replies, so Alice performs a DH ratchet step; her subsequent
+                // messages are regular (whisper) messages on a fresh sending chain.
+                const cr = await bCipher.encrypt(util.toArrayBuffer("reply") as ArrayBuffer);
+                await aCipher.decryptWhisperMessage(cr.body, "binary");
+
+                // Two consecutive whisper messages: the counter advances 0 -> 1
+                // while the ratchet key stays the same (no further DH step).
+                const c1 = await aCipher.encrypt(util.toArrayBuffer("whisper-0") as ArrayBuffer);
+                const c2 = await aCipher.encrypt(util.toArrayBuffer("whisper-1") as ArrayBuffer);
+                const r1 = await bCipher.decryptWhisperMessage(c1.body, "binary");
+                const r2 = await bCipher.decryptWhisperMessage(c2.body, "binary");
+                assert.strictEqual(r1.ratchet.counter, 0);
+                assert.strictEqual(r2.ratchet.counter, 1);
+                assertEqualArrayBuffers(r2.ratchet.key, r1.ratchet.key);
             });
         });
     }
@@ -215,7 +251,7 @@ describe("OMEMO 2 cross-implementation vector (libomemo-c)", function () {
     });
 
     it("decrypts libomemo-c's key-exchange message", async function () {
-        const pt = await bobCipher.decryptPreKeyWhisperMessage(
+        const { plaintext: pt } = await bobCipher.decryptPreKeyWhisperMessage(
             hexToArrayBuffer(LIBOMEMO_C_VECTOR.ciphertext1),
             "binary"
         );
@@ -223,7 +259,7 @@ describe("OMEMO 2 cross-implementation vector (libomemo-c)", function () {
     });
 
     it("decrypts a second message on the same chain (counter advances)", async function () {
-        const pt = await bobCipher.decryptPreKeyWhisperMessage(
+        const { plaintext: pt } = await bobCipher.decryptPreKeyWhisperMessage(
             hexToArrayBuffer(LIBOMEMO_C_VECTOR.ciphertext2),
             "binary"
         );

--- a/test/session-builder.ts
+++ b/test/session-builder.ts
@@ -39,7 +39,7 @@ describe("SessionBuilder", function () {
         it("the session can encrypt", async function () {
             const ciphertext = await aliceSessionCipher.encrypt(originalMessage);
             assert.strictEqual(ciphertext.type, 3); // PREKEY_BUNDLE
-            const plaintext = await bobSessionCipher.decryptPreKeyWhisperMessage(
+            const { plaintext } = await bobSessionCipher.decryptPreKeyWhisperMessage(
                 ciphertext.body,
                 "binary"
             );
@@ -48,7 +48,7 @@ describe("SessionBuilder", function () {
 
         it("the session can decrypt", async function () {
             const ciphertext = await bobSessionCipher.encrypt(originalMessage);
-            const plaintext = await aliceSessionCipher.decryptWhisperMessage(
+            const { plaintext } = await aliceSessionCipher.decryptWhisperMessage(
                 ciphertext.body,
                 "binary"
             );
@@ -127,7 +127,7 @@ describe("SessionBuilder", function () {
             const ciphertext = await aliceSessionCipher.encrypt(originalMessage);
             assert.strictEqual(ciphertext.type, 3); // PREKEY_BUNDLE
 
-            const plaintext = await bobSessionCipher.decryptPreKeyWhisperMessage(
+            const { plaintext } = await bobSessionCipher.decryptPreKeyWhisperMessage(
                 ciphertext.body,
                 "binary"
             );
@@ -136,7 +136,7 @@ describe("SessionBuilder", function () {
 
         it("the session can decrypt", async function () {
             const ciphertext = await bobSessionCipher.encrypt(originalMessage);
-            const plaintext = await aliceSessionCipher.decryptWhisperMessage(
+            const { plaintext } = await aliceSessionCipher.decryptWhisperMessage(
                 ciphertext.body,
                 "binary"
             );

--- a/test/session-cipher.ts
+++ b/test/session-cipher.ts
@@ -225,11 +225,11 @@ describe("SessionCipher", function () {
         if (data.type == Type.CIPHERTEXT) {
             plaintext = await sessionCipher
                 .decryptWhisperMessage(data.message, "binary")
-                .then(unpad);
+                .then((r) => unpad(r.plaintext));
         } else if (data.type == Type.PREKEY_BUNDLE) {
             plaintext = await sessionCipher
                 .decryptPreKeyWhisperMessage(data.message, "binary")
-                .then(unpad);
+                .then((r) => unpad(r.plaintext));
         } else {
             throw new Error("Unknown data type in test vector");
         }
@@ -443,7 +443,7 @@ describe("SessionCipher", function () {
         describe("decryptWhisperMessage", function () {
             it("accepts encoding='binary'", async function () {
                 const ciphertext = await bobSessionCipher.encrypt(originalMessage);
-                const plaintext = await aliceSessionCipher.decryptWhisperMessage(
+                const { plaintext } = await aliceSessionCipher.decryptWhisperMessage(
                     ciphertext.body,
                     "binary"
                 );
@@ -452,7 +452,7 @@ describe("SessionCipher", function () {
 
             it("accepts encoding='base64'", async function () {
                 const ciphertext = await bobSessionCipher.encrypt(originalMessage);
-                const plaintext = await aliceSessionCipher.decryptWhisperMessage(
+                const { plaintext } = await aliceSessionCipher.decryptWhisperMessage(
                     btoa(ciphertext.body),
                     "base64"
                 );
@@ -461,7 +461,7 @@ describe("SessionCipher", function () {
 
             it("accepts encoding='hex'", async function () {
                 const ciphertext = await bobSessionCipher.encrypt(originalMessage);
-                const plaintext = await aliceSessionCipher.decryptWhisperMessage(
+                const { plaintext } = await aliceSessionCipher.decryptWhisperMessage(
                     hexEncode(ciphertext.body),
                     "hex"
                 );


### PR DESCRIPTION
The OMEMO heartbeat rule (XEP-0384: "the first message for a given ratchet key with a counter of 53 or higher") requires knowing, for a just-decrypted message, its Double Ratchet counter and the sender's ratchet key.

Change `decryptWhisperMessage`/`decryptPreKeyWhisperMessage` to return a `DecryptResult` (`{ plaintext, ratchet: { counter, key } }`) instead of a bare plaintext ArrayBuffer. Both values were already parsed internally and are normalized across the legacy (0.3.0) and omemo:2 profiles, so the new field is the same shape for both.

This is a breaking change to the decrypt return type; bumped to 2.0.0-rc.2.